### PR TITLE
ci: upload the .tgz created for npm as part of the release

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,12 +108,8 @@
         {
           "assets": [
             {
-              "path": "dist",
+              "path": "*.tgz",
               "label": "Browser extension background"
-            },
-            {
-              "path": "src",
-              "label": "Source"
             }
           ]
         }


### PR DESCRIPTION
This is an attempt at fixing the release workflow.