### PR TITLE
ci: use cached build for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,15 @@ jobs:
   publish-extension:
     runs-on: ubuntu-latest
     needs: js-test-and-release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.js-test-and-release.outputs.release == 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
-      - run: npm ci
+      - uses: ipfs/aegir/actions/cache-node-modules@main
       - run: npm run package
       - run: npm run publish:chrome-store
         env:

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "sync-version": "node scripts/sync-version.mjs",
     "build": "npm run sync-version && tsc && cp src/manifest.json dist/ && cp src/popup.html dist/ && cp -r src/icons dist/",
-    "package": "npm run build && web-ext build --source-dir=dist --artifacts-dir=. --filename=ipfs-quicklaunch.zip --overwrite-dest",
-    "publish:chrome-store": "npx cws-publish $CHROME_CLIENT_ID $CHROME_CLIENT_SECRET $CHROME_REFRESH_TOKEN ipfs-quicklaunch.zip $CHROME_EXTENSION_ID",
+    "package": "web-ext build --source-dir=dist --artifacts-dir=. --filename=ipfs-quicklaunch.zip --overwrite-dest",
+    "publish:chrome-store": "npx cws-publish \"$CHROME_CLIENT_ID\" \"$CHROME_CLIENT_SECRET\" \"$CHROME_REFRESH_TOKEN\" ipfs-quicklaunch.zip \"$CHROME_EXTENSION_ID\"",
     "release": "aegir release",
     "start": "npm run build && web-ext run --source-dir=dist --target=chromium",
     "watch": "tsc --watch",


### PR DESCRIPTION
This PR ensures that we use the cached build for the publishing if available. The build should be cached when `js-test-and-release` runs.

This PR also introduces usage of the new `release` (https://github.com/ipdxco/unified-github-workflows/releases/tag/v1.0.30) output of the `js-test-and-release` job. The output indicates whether a release was attempted or not.